### PR TITLE
Load init.php via phpunit.xml

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,1 @@
+<phpunit bootstrap="./init.php"></phpunit>

--- a/test_go_to.php
+++ b/test_go_to.php
@@ -1,5 +1,4 @@
 <?php
-require_once dirname( __FILE__ ) . '/init.php';
 
 class WP_Test_Go_To extends WP_UnitTestCase {
 	

--- a/test_plugin.php
+++ b/test_plugin.php
@@ -1,5 +1,4 @@
 <?php
-require_once dirname( __FILE__ ) . '/init.php';
 
 class WP_Test_Hello_Dolly extends WP_UnitTestCase {
 

--- a/test_test.php
+++ b/test_test.php
@@ -1,5 +1,4 @@
 <?php
-require_once dirname( __FILE__ ) . '/init.php';
 
 class WP_Is_Email_Test extends WP_UnitTestCase {
 

--- a/test_texturize.php
+++ b/test_texturize.php
@@ -1,5 +1,4 @@
 <?php
-require_once dirname( __FILE__ ) . '/init.php';
 
 class WP_Test_Texturize extends WP_UnitTestCase {
 	function test_dont_texturize_dashes_in_code() {


### PR DESCRIPTION
Having to require() init.php in each test file is repetitive and makes it hard to have test files in a different directory.

Fortunately, phpunit has a --bootstrap option, which can be read from a phpunit.xml file.
