### PR TITLE
Undefined var $table_prefix

### DIFF
--- a/unittests-config-sample.php
+++ b/unittests-config-sample.php
@@ -16,4 +16,4 @@ define( 'WP_DEBUG_DISPLAY', true );
 /* Cron tries to make an HTTP request to the blog, which always fails, because tests are run in CLI mode only */
 define( 'DISABLE_WP_CRON', true );
 
-$GLOBALS['table_prefix']  = 'wp_';
+$GLOBALS['table_prefix'] = $table_prefix = 'wp_';


### PR DESCRIPTION
WordPress now [explicitly globalizes $table_prefix](http://core.trac.wordpress.org/ticket/17749#comment:27) in
case it isn't loaded in the global scope, so $table_prefix can be local in the config
