### PR TITLE
Fix memory limit issue

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,1 +1,5 @@
-<phpunit bootstrap="./init.php"></phpunit>
+<phpunit bootstrap="./init.php">
+	<php>
+		<ini name="memory_limit" value="-1" />
+	</php>
+</phpunit>


### PR DESCRIPTION
While trying to run `phpunit --coverage-html`, I ran into a memory limit error.

I checked my `/etc/php5/cli/php.ini` file and it looked fine:

```
memory_limit = -1
```

However, when I did a manual `var_dump( ini_get( 'memory_limit' ) );` in one of phpunit's files, I got back '32M'.

Not exactly sure what's happening here, but setting the memory limit inside phpunit.xml seems to solve the problem.
