### PR TITLE
Multisite support for wordpress-tests

### DIFF
--- a/bin/install.php
+++ b/bin/install.php
@@ -48,26 +48,18 @@ echo "Installing…\n";
 wp_install( WP_TESTS_TITLE, 'admin', WP_TESTS_EMAIL, true, '', 'a' );
 
 if ( defined('WP_ALLOW_MULTISITE') && WP_ALLOW_MULTISITE ) {
+	echo "Installing network…\n";
+
 	define( 'WP_INSTALLING_NETWORK', true );
 	//wp_set_wpdb_vars();
 	// We need to create references to ms global tables to enable Network.
 	foreach ( $wpdb->tables( 'ms_global' ) as $table => $prefixed_table )
 		$wpdb->$table = $prefixed_table;
 	install_network();
-	$result = populate_network(1, WP_TESTS_DOMAIN, WP_TESTS_EMAIL, WP_TESTS_NETWORK_TITLE, ABSPATH, SUBDOMAIN_INSTALL);
+	$result = populate_network(1, WP_TESTS_DOMAIN, WP_TESTS_EMAIL, WP_TESTS_NETWORK_TITLE, ABSPATH, WP_TESTS_SUBDOMAIN_INSTALL);
 
-	$blogs = explode(',', WP_TESTS_BLOGS);
-	foreach ( $blogs as $blog ) {
-		if ( SUBDOMAIN_INSTALL ) {
-			$newdomain = $blog.'.'.preg_replace( '|^www\.|', '', WP_TESTS_DOMAIN );
-			$path = $base;
-		} else {
-			$newdomain = WP_TESTS_DOMAIN;
-			$path = $base.$blog.'/';
-		}
-		wpmu_create_blog( $newdomain, $path, $blog, email_exists(WP_TESTS_EMAIL) , array( 'public' => 1 ), 1 );
+	system( 'php '.escapeshellarg( dirname( __FILE__ ) . '/ms-install.php' ) . ' ' . escapeshellarg( $config_file_path ) );
 
-	}
 }
 
 file_put_contents( WP_TESTS_DB_VERSION_FILE, get_option('db_version') );

--- a/bin/ms-install.php
+++ b/bin/ms-install.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Installs additional MU sites for the purpose of the unit-tests
+ *
+ * @todo Reuse the init/load code in init.php
+ */
+error_reporting( E_ALL & ~E_DEPRECATED & ~E_STRICT );
+
+$config_file_path = $argv[1];
+
+require_once $config_file_path;
+
+$_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
+$_SERVER['HTTP_HOST'] = WP_TESTS_DOMAIN;
+$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+$PHP_SELF = $GLOBALS['PHP_SELF'] = $_SERVER['PHP_SELF'] = '/index.php';
+
+require_once ABSPATH . '/wp-settings.php';
+
+require_once ABSPATH . '/wp-admin/includes/upgrade.php';
+require_once ABSPATH . '/wp-includes/wp-db.php';
+
+echo "Installing sites…\n";
+wp_install( WP_TESTS_TITLE, 'admin', WP_TESTS_EMAIL, true, '', 'a' );
+
+if ( defined('WP_ALLOW_MULTISITE') && WP_ALLOW_MULTISITE ) {
+	$blogs = explode(',', WP_TESTS_BLOGS);
+	foreach ( $blogs as $blog ) {
+		if ( WP_TESTS_SUBDOMAIN_INSTALL ) {
+			$newdomain = $blog.'.'.preg_replace( '|^www\.|', '', WP_TESTS_DOMAIN );
+			$path = $base;
+		} else {
+			$newdomain = WP_TESTS_DOMAIN;
+			$path = $base.$blog.'/';
+		}
+		wpmu_create_blog( $newdomain, $path, $blog, email_exists(WP_TESTS_EMAIL) , array( 'public' => 1 ), 1 );
+
+	}
+}

--- a/init.php
+++ b/init.php
@@ -16,14 +16,16 @@ See: https://github.com/sebastianbergmann/phpunit/issues/325
 These are not needed for WordPress 3.3+, only for older versions
 */
 global $table_prefix, $wp_embed, $wp_locale, $_wp_deprecated_widgets_callbacks, $wp_widget_factory;
+// These are still needed
+global $wpdb, $current_site, $current_blog, $wp_rewrite;
+require_once $config_file_path;
 
 $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
-$_SERVER['HTTP_HOST'] = 'example.org';
+$_SERVER['HTTP_HOST'] = WP_TESTS_DOMAIN;
 $PHP_SELF = $GLOBALS['PHP_SELF'] = $_SERVER['PHP_SELF'] = '/index.php';
 
 system( 'php '.escapeshellarg( dirname( __FILE__ ) . '/bin/install.php' ) . ' ' . escapeshellarg( $config_file_path ) );
 
-require_once $config_file_path;
 
 require_once ABSPATH . '/wp-settings.php';
 require dirname( __FILE__ ) . '/lib/testcase.php';

--- a/unittests-config-sample.php
+++ b/unittests-config-sample.php
@@ -17,22 +17,23 @@ define( 'WP_TESTS_DOMAIN', 'example.org' );
 define( 'WP_TESTS_EMAIL', 'admin@example.org' );
 define( 'WP_TESTS_TITLE', 'Test Blog' );
 define( 'WP_TESTS_NETWORK_TITLE', 'Test Network' );
+define( 'WP_TESTS_SUBDOMAIN_INSTALL', true );
+$base = '/';
 
 /* Cron tries to make an HTTP request to the blog, which always fails, because tests are run in CLI mode only */
 define( 'DISABLE_WP_CRON', true );
 
 define( 'WP_ALLOW_MULTISITE', false );
 if ( WP_ALLOW_MULTISITE ) {
-	define( 'SUBDOMAIN_INSTALL', true );
-	define( 'DOMAIN_CURRENT_SITE', WP_TESTS_DOMAIN );
-	$base = '/';
-	define( 'PATH_CURRENT_SITE', '/' );
-	define( 'SITE_ID_CURRENT_SITE', 1 );
-	define( 'BLOG_ID_CURRENT_SITE', 1 );
 	define( 'WP_TESTS_BLOGS', 'first,second,third,fourth' );
 }
 if ( WP_ALLOW_MULTISITE && !defined('WP_INSTALLING') ) {
+	define( 'SUBDOMAIN_INSTALL', WP_TESTS_SUBDOMAIN_INSTALL );
 	define( 'MULTISITE', true );
+	define( 'DOMAIN_CURRENT_SITE', WP_TESTS_DOMAIN );
+	define( 'PATH_CURRENT_SITE', '/' );
+	define( 'SITE_ID_CURRENT_SITE', 1);
+	define( 'BLOG_ID_CURRENT_SITE', 1);
 	//define( 'SUNRISE', TRUE );
 }
 

--- a/unittests-config-sample.php
+++ b/unittests-config-sample.php
@@ -13,7 +13,27 @@ define( 'WPLANG', '' );
 define( 'WP_DEBUG', true );
 define( 'WP_DEBUG_DISPLAY', true );
 
+define( 'WP_TESTS_DOMAIN', 'example.org' );
+define( 'WP_TESTS_EMAIL', 'admin@example.org' );
+define( 'WP_TESTS_TITLE', 'Test Blog' );
+define( 'WP_TESTS_NETWORK_TITLE', 'Test Network' );
+
 /* Cron tries to make an HTTP request to the blog, which always fails, because tests are run in CLI mode only */
 define( 'DISABLE_WP_CRON', true );
+
+define( 'WP_ALLOW_MULTISITE', false );
+if ( WP_ALLOW_MULTISITE ) {
+	define( 'SUBDOMAIN_INSTALL', true );
+	define( 'DOMAIN_CURRENT_SITE', WP_TESTS_DOMAIN );
+	$base = '/';
+	define( 'PATH_CURRENT_SITE', '/' );
+	define( 'SITE_ID_CURRENT_SITE', 1 );
+	define( 'BLOG_ID_CURRENT_SITE', 1 );
+	define( 'WP_TESTS_BLOGS', 'first,second,third,fourth' );
+}
+if ( WP_ALLOW_MULTISITE && !defined('WP_INSTALLING') ) {
+	define( 'MULTISITE', true );
+	//define( 'SUNRISE', TRUE );
+}
 
 $table_prefix  = 'wp_';


### PR DESCRIPTION
Hi, Nikolay,

I've hacked wordpress-tests to enable support for multisite. Basically, you can (optionally) set some options in your unittests-config.php that tell the install script to setup multisite and instantiate additional blogs.

Have a nice day,
Jonathan Brinley
