### PR TITLE
Bootstrapping WordPress with early hooks.

### DIFF
--- a/bootstrap-with-hooks.php
+++ b/bootstrap-with-hooks.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Bootstrap with early WordPress hooks, which allows for overriding 
+ * some settings like activated plugins and theme without modifying 
+ * database. 
+ *
+ * To run PHPUnit with this bootstrap, please use this command:
+ *
+ *    $ phpunit --bootstrap bootstrap-with-hooks.php all
+ */
+
+$GLOBALS['hooks'] = array();
+
+// Activate the Hello Dolly plugin
+$GLOBALS['hooks'][] = function() {
+	add_filter('option_active_plugins', function($plugins){
+		$plugins[] = 'hello.php';
+		return $plugins;
+	});
+};
+
+// Activate the TwentyEleven theme.
+$GLOBALS['hooks'][] = function() {
+	add_filter('option_template', function($stylesheet){
+		return 'twentyeleven';
+	});
+
+	add_filter('option_stylesheet', function($stylesheet){
+		return 'twentyeleven';
+	});
+};
+
+/**
+ * Initiate WordPress-tests
+ */
+
+$path = 'init.php';
+
+if( file_exists( $path ) ) {
+    require_once $path;
+} else {
+    exit( "Couldn't find path to wordpress-tests/init.php\n" );
+}

--- a/init.php
+++ b/init.php
@@ -49,9 +49,10 @@ if(isset($GLOBALS['wp_tests_options'])) {
 
 // Load the rest of wp-settings.php, start from where we left off.
 $wp_settings_content = file_get_contents(ABSPATH.'/wp-settings.php');
-$offset = strpos($wp_settings_content, '// Load the l18n library.');
+$shortinit_phrase = "if ( SHORTINIT )\n\treturn false;\n";
+$offset = strpos($wp_settings_content, $shortinit_phrase)+strlen($shortinit_phrase);
 eval(substr($wp_settings_content, $offset));
-unset($wp_settings_content, $offset);
+unset($wp_settings_content, $offset, $shortinit_phrase);
 
 require dirname( __FILE__ ) . '/lib/testcase.php';
 require dirname( __FILE__ ) . '/lib/exceptions.php';

--- a/init.php
+++ b/init.php
@@ -34,7 +34,14 @@ define('SHORTINIT', true);
 // Load the basics part of WordPress.
 require_once ABSPATH . '/wp-settings.php';
 
-// TODO: inject some code here.
+// Load early WordPress hooks defined in the bootstrap file.
+if(isset($GLOBALS['hooks'])) {
+	foreach ($GLOBALS['hooks'] as $function) {
+		$function();
+	}
+
+	unset($GLOBALS['hooks']);
+}
 
 // Load the rest of wp-settings.php, start from where we left off.
 $wp_settings_content = file_get_contents(ABSPATH.'/wp-settings.php');

--- a/init.php
+++ b/init.php
@@ -28,7 +28,18 @@ $PHP_SELF = $GLOBALS['PHP_SELF'] = $_SERVER['PHP_SELF'] = '/index.php';
 
 system( 'php '.escapeshellarg( dirname( __FILE__ ) . '/bin/install.php' ) . ' ' . escapeshellarg( $config_file_path ) );
 
+// Stop most of WordPress from being loaded.
+define('SHORTINIT', true);
 
+// Load the basics part of WordPress.
 require_once ABSPATH . '/wp-settings.php';
+
+// TODO: inject some code here.
+
+// Load the rest of wp-settings.php, start from where we left off.
+$wp_settings_content = file_get_contents(ABSPATH.'/wp-settings.php');
+$offset = strpos($wp_settings_content, '// Load the l18n library.');
+eval(substr($wp_settings_content, $offset));
+
 require dirname( __FILE__ ) . '/lib/testcase.php';
 require dirname( __FILE__ ) . '/lib/exceptions.php';

--- a/init.php
+++ b/init.php
@@ -34,13 +34,32 @@ define('SHORTINIT', true);
 // Load the basics part of WordPress.
 require_once ABSPATH . '/wp-settings.php';
 
-// Load early WordPress hooks defined in the bootstrap file.
-if(isset($GLOBALS['hooks'])) {
-	foreach ($GLOBALS['hooks'] as $function) {
-		$function();
-	}
+// Load active plugins and theme via ealry hooks defined in bootstarp file.
+if(isset($GLOBALS['wp_tests_config'])) {
+	$config = $GLOBALS['wp_tests_config'];
 
-	unset($GLOBALS['hooks']);
+	foreach ($config as $name => $value) :
+		switch ($name) :
+			case 'plugins':
+				if(!is_array($value)) break;
+
+				add_filter('option_active_plugins', function($plugins) use ($config) {
+					return array_merge($plugins, $config['plugins']);
+				});
+
+				break;
+			
+			case 'template':
+			case 'stylesheet':
+				add_filter("option_{$name}", function($template) use ($config, $name) {
+					return $config[$name];
+				});
+
+				break;
+		endswitch;
+	endforeach;
+
+	unset($GLOBALS['wp_tests_config'], $config);
 }
 
 // Load the rest of wp-settings.php, start from where we left off.

--- a/init.php
+++ b/init.php
@@ -40,6 +40,7 @@ require_once ABSPATH . '/wp-settings.php';
 $wp_settings_content = file_get_contents(ABSPATH.'/wp-settings.php');
 $offset = strpos($wp_settings_content, '// Load the l18n library.');
 eval(substr($wp_settings_content, $offset));
+unset($wp_settings_content, $offset);
 
 require dirname( __FILE__ ) . '/lib/testcase.php';
 require dirname( __FILE__ ) . '/lib/exceptions.php';

--- a/init.php
+++ b/init.php
@@ -34,32 +34,17 @@ define('SHORTINIT', true);
 // Load the basics part of WordPress.
 require_once ABSPATH . '/wp-settings.php';
 
-// Load active plugins and theme via ealry hooks defined in bootstarp file.
-if(isset($GLOBALS['wp_tests_config'])) {
-	$config = $GLOBALS['wp_tests_config'];
+// Preset WordPress options defined in bootstarp file.
+// Used to activate theme and plugins.
+if(isset($GLOBALS['wp_tests_options'])) {
+	function wp_tests_options( $value ) {
+		$key = substr( current_filter(), strlen( 'pre_option_' ) );
+		return $GLOBALS['wp_tests_options'][$key];
+	}
 
-	foreach ($config as $name => $value) :
-		switch ($name) :
-			case 'plugins':
-				if(!is_array($value)) break;
-
-				add_filter('option_active_plugins', function($plugins) use ($config) {
-					return array_merge($plugins, $config['plugins']);
-				});
-
-				break;
-			
-			case 'template':
-			case 'stylesheet':
-				add_filter("option_{$name}", function($template) use ($config, $name) {
-					return $config[$name];
-				});
-
-				break;
-		endswitch;
-	endforeach;
-
-	unset($GLOBALS['wp_tests_config'], $config);
+	foreach ( array_keys( $GLOBALS['wp_tests_options'] ) as $key ) {
+		add_filter( 'pre_option_'.$key, 'wp_tests_options' );
+	}
 }
 
 // Load the rest of wp-settings.php, start from where we left off.

--- a/test_plugin.php
+++ b/test_plugin.php
@@ -1,9 +1,6 @@
 <?php
 
 class WP_Test_Hello_Dolly extends WP_UnitTestCase {
-
-	var $plugin_slug = 'hello';
-	
 	function test_hello_dolly() {
 		ob_start();
 		hello_dolly();


### PR DESCRIPTION
###### The Problem

As discussed in issue #16, the current wordpress-tests isn't activating plugins in the correct order; plugins should be loaded before theme is activated. 

Also, this project cannot used to test WordPress theme because it cannot switch theme when WordPress is initiating.
###### The Solution

By modifying the result returned by `wp_get_active_and_valid_plugins()` and the `TEMPLATEPATH`, `STYLESHEETPATH` constants in `wp-settings.php`, we can activate plugins and theme without touching the database. This can be done by adding filters.

In order to do this, I have made this project able to add early hooks right after the basic part of WordPress is done loading.
###### Usages

User can add early hooks in their `bootstrap.php` file.

``` php
<?php
$GLOBALS['hooks'] = array();

// Activate the Hello Dolly plugin
$GLOBALS['hooks'][] = function() {
    add_filter('option_active_plugins', function($plugins){
        $plugins[] = 'hello.php';
        return $plugins;
    });
};

// ...

require_once 'init.php';
```

A sample bootstrap file has been attached in this pull request. Please try the following command.

`phpunit --bootstrap bootstrap-with-hooks.php all`
