### PR TITLE
Phing build files and phpunitreport configuration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-unittests-config.php
+/build
+/unittests-config.php

--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project name="WordPress Unit Tests" default="build" basedir=".">
+	<target name="clean">
+		<delete dir="build" />
+	</target>
+	<target name="prepare">
+		<mkdir dir="build/logs" />
+		<mkdir dir="build/phpunitreport" />
+	</target>
+	<target name="phpunit">
+		<phpunit bootstrap="init.php" printsummary="true" haltonfailure="false">
+			<formatter todir="build/logs" type="xml" outfile="junit.xml" />
+			<batchtest>
+				<fileset dir=".">
+					<include name="test_*.php" />
+				</fileset>
+			</batchtest>
+		</phpunit>
+		<phpunitreport infile="build/logs/junit.xml" format="frames" todir="build/phpunitreport" />
+	</target>
+	<target name="build" depends="clean,prepare,phpunit" />
+</project>


### PR DESCRIPTION
Install necessary dependencies:
- Phing
- XSLTProcessor (enable php5-xsl extension)
- PHPUnit of course

Then just run `phing`. Test should be run, and report will be waiting in `build/phpunitreport/index.html`.

You should see something that looks like this:
http://ibaku.net/wordpress/phpunitreport/
