### PR TITLE
Windows compatibility

### DIFF
--- a/bin/install.php
+++ b/bin/install.php
@@ -38,11 +38,11 @@ $wpdb->query( 'DROP DATABASE IF EXISTS '.DB_NAME.";" );
 $wpdb->query( 'CREATE DATABASE '.DB_NAME.";" );
 $wpdb->select( DB_NAME, $wpdb->dbh );
 
-echo "Installing…\n";
+echo "Installing…" . PHP_EOL;
 wp_install( WP_TESTS_TITLE, 'admin', WP_TESTS_EMAIL, true, '', 'a' );
 
 if ( defined('WP_ALLOW_MULTISITE') && WP_ALLOW_MULTISITE ) {
-	echo "Installing network…\n";
+	echo "Installing network…" .PHP_EOL;
 
 	define( 'WP_INSTALLING_NETWORK', true );
 	//wp_set_wpdb_vars();

--- a/bin/install.php
+++ b/bin/install.php
@@ -52,7 +52,7 @@ if ( defined('WP_ALLOW_MULTISITE') && WP_ALLOW_MULTISITE ) {
 	install_network();
 	$result = populate_network(1, WP_TESTS_DOMAIN, WP_TESTS_EMAIL, WP_TESTS_NETWORK_TITLE, ABSPATH, WP_TESTS_SUBDOMAIN_INSTALL);
 
-	system( 'php '.escapeshellarg( dirname( __FILE__ ) . '/ms-install.php' ) . ' ' . escapeshellarg( $config_file_path ) );
+	system( WP_PHP_BINARY . ' ' . escapeshellarg( dirname( __FILE__ ) . '/ms-install.php' ) . ' ' . escapeshellarg( $config_file_path ) );
 
 }
 

--- a/bin/ms-install.php
+++ b/bin/ms-install.php
@@ -20,7 +20,7 @@ require_once ABSPATH . '/wp-settings.php';
 require_once ABSPATH . '/wp-admin/includes/upgrade.php';
 require_once ABSPATH . '/wp-includes/wp-db.php';
 
-echo "Installing sites…\n";
+echo "Installing sites…" . PHP_EOL;
 wp_install( WP_TESTS_TITLE, 'admin', WP_TESTS_EMAIL, true, '', 'a' );
 
 if ( defined('WP_ALLOW_MULTISITE') && WP_ALLOW_MULTISITE ) {

--- a/init.php
+++ b/init.php
@@ -48,8 +48,8 @@ if(isset($GLOBALS['wp_tests_options'])) {
 }
 
 // Load the rest of wp-settings.php, start from where we left off.
-$wp_settings_content = file_get_contents(ABSPATH.'/wp-settings.php');
-$shortinit_phrase = "if ( SHORTINIT )\n\treturn false;\n";
+$wp_settings_content = file_get_contents(ABSPATH . '/wp-settings.php');
+$shortinit_phrase = "if ( SHORTINIT )" . PHP_EOL . "\treturn false;" . PHP_EOL;
 $offset = strpos($wp_settings_content, $shortinit_phrase)+strlen($shortinit_phrase);
 eval(substr($wp_settings_content, $offset));
 unset($wp_settings_content, $offset, $shortinit_phrase);

--- a/init.php
+++ b/init.php
@@ -26,7 +26,7 @@ $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
 $_SERVER['HTTP_HOST'] = WP_TESTS_DOMAIN;
 $PHP_SELF = $GLOBALS['PHP_SELF'] = $_SERVER['PHP_SELF'] = '/index.php';
 
-system( 'php '.escapeshellarg( dirname( __FILE__ ) . '/bin/install.php' ) . ' ' . escapeshellarg( $config_file_path ) );
+system( WP_PHP_BINARY . ' ' . escapeshellarg( dirname( __FILE__ ) . '/bin/install.php' ) . ' ' . escapeshellarg( $config_file_path ) );
 
 // Stop most of WordPress from being loaded.
 define('SHORTINIT', true);

--- a/unittests-config-sample.php
+++ b/unittests-config-sample.php
@@ -38,3 +38,5 @@ if ( WP_ALLOW_MULTISITE && !defined('WP_INSTALLING') ) {
 }
 
 $table_prefix  = 'wp_';
+
+define( 'WP_PHP_BINARY', 'php' );


### PR DESCRIPTION
Two changes to make the suite more compatible with Windows environments:
- Change all hard-coded "\n" instances to PHP_EOL constant.
- Allow configuration of the PHP executable path from the config file. This also helps anyone who has multiple versions of PHP installed and wants to use a non-system-default version.
