### PR TITLE
Improvements to the handling of MultiSite and test discovery

### DIFF
--- a/all.php
+++ b/all.php
@@ -14,8 +14,9 @@ for( $depth = 0; $depth <= 3; $depth++ ) {
 class all {
     public static function suite() {
         $suite = new PHPUnit_Framework_TestSuite();
+		
 		foreach( get_declared_classes() as $class ) {
-			if ( preg_match( '/^WP_Test_/', $class ) ) {
+			if ( is_subclass_of( $class, 'WP_UnitTestCase' ) ) {
 				$suite->addTestSuite( $class );
 			}
 		}

--- a/bin/install.php
+++ b/bin/install.php
@@ -50,7 +50,7 @@ if ( defined('WP_ALLOW_MULTISITE') && WP_ALLOW_MULTISITE ) {
 	foreach ( $wpdb->tables( 'ms_global' ) as $table => $prefixed_table )
 		$wpdb->$table = $prefixed_table;
 	install_network();
-	$result = populate_network(1, WP_TESTS_DOMAIN, WP_TESTS_EMAIL, WP_TESTS_NETWORK_TITLE, ABSPATH, WP_TESTS_SUBDOMAIN_INSTALL);
+	$result = populate_network(1, WP_TESTS_DOMAIN, WP_TESTS_EMAIL, WP_TESTS_NETWORK_TITLE, '/', WP_TESTS_SUBDOMAIN_INSTALL);
 
 	system( WP_PHP_BINARY . ' ' . escapeshellarg( dirname( __FILE__ ) . '/ms-install.php' ) . ' ' . escapeshellarg( $config_file_path ) );
 

--- a/bin/install.php
+++ b/bin/install.php
@@ -8,8 +8,11 @@ error_reporting( E_ALL & ~E_DEPRECATED & ~E_STRICT );
 
 $config_file_path = $argv[1];
 
+$config_dir = dirname( $config_file_path );
+
 define( 'WP_INSTALLING', true );
 require_once $config_file_path;
+require_once $config_dir . '/lib/functions.php';
 
 $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
 $_SERVER['HTTP_HOST'] = WP_TESTS_DOMAIN;
@@ -20,16 +23,15 @@ require_once ABSPATH . '/wp-settings.php';
 require_once ABSPATH . '/wp-admin/includes/upgrade.php';
 require_once ABSPATH . '/wp-includes/wp-db.php';
 
-define( 'WP_TESTS_DB_VERSION_FILE', ABSPATH . '.wp-tests-db-version' );
+define( 'WP_TESTS_VERSION_FILE', ABSPATH . '.wp-tests-version' );
 
 $wpdb->suppress_errors();
 $wpdb->hide_errors();
 $installed = $wpdb->get_var( "SELECT option_value FROM $wpdb->options WHERE option_name = 'siteurl'" );
 
-if ( $installed && file_exists( WP_TESTS_DB_VERSION_FILE ) ) {
-	$install_db_version = file_get_contents( WP_TESTS_DB_VERSION_FILE );
-	$db_version = get_option( 'db_version' );
-	if ( $db_version == $install_db_version ) {
+if ( $installed && file_exists( WP_TESTS_VERSION_FILE ) ) {
+	$installed_version_hash = file_get_contents( WP_TESTS_VERSION_FILE );
+	if ( $installed_version_hash == test_version_check_hash() ) {
 		return;
 	}
 }
@@ -56,4 +58,4 @@ if ( defined('WP_ALLOW_MULTISITE') && WP_ALLOW_MULTISITE ) {
 
 }
 
-file_put_contents( WP_TESTS_DB_VERSION_FILE, get_option('db_version') );
+file_put_contents( WP_TESTS_VERSION_FILE, test_version_check_hash() );

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -1,4 +1,30 @@
 <?php
+/**
+ * Generate a hash to be used when comparing installed version against
+ * codebase and current configuration
+ * @return string $hash sha1 hash
+ **/
+function test_version_check_hash() {
+	$hash = '';
+	$db_version = get_option( 'db_version' );
+	if ( defined('WP_ALLOW_MULTISITE') && WP_ALLOW_MULTISITE ) {
+		$version = $db_version;
+		if( defined( 'WP_TESTS_BLOGS' ) ) {
+			$version .= WP_TESTS_BLOGS;
+		}
+		if( defined( 'WP_TESTS_SUBDOMAIN_INSTALL' ) ) {
+			$version .= WP_TESTS_SUBDOMAIN_INSTALL;
+		}
+		if( defined( 'WP_TESTS_DOMAIN' ) ) {
+			$version .= WP_TESTS_DOMAIN;
+		}
+
+	} else {
+		$version = $db_version;
+	}
+
+	return sha1($version);
+}
 
 // For adding hooks before loading WP
 function tests_add_filter($tag, $function_to_add, $priority = 10, $accepted_args = 1) {


### PR DESCRIPTION
This fixes #23 by using a sha1 hash of the db_version and the MultiSite configuration constants WP_TESTS_BLOGS, WP_TESTS_SUBDOMAIN_INSTALL, WP_TESTS_DOMAIN if WP_ALLOW_MULTISITE is true.

I also fixed a problem with populate_network() and switched to using is_subclass_of() to allow deeper inheritance trees in all.php
