### PR TITLE
Update install.php: define SERVER_NAME so sending email works.

### DIFF
--- a/bin/install.php
+++ b/bin/install.php
@@ -16,6 +16,7 @@ require_once $config_dir . '/lib/functions.php';
 
 $_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1';
 $_SERVER['HTTP_HOST'] = WP_TESTS_DOMAIN;
+$_SERVER['SERVER_NAME'] = WP_TESTS_DOMAIN;
 $PHP_SELF = $GLOBALS['PHP_SELF'] = $_SERVER['PHP_SELF'] = '/index.php';
 
 require_once ABSPATH . '/wp-settings.php';


### PR DESCRIPTION
Attempting to send an email throws an Undefined Index error on SERVER_NAME.  Setting $_SERVER['SERVER_NAME'] to WP_TESTS_DOMAIN resolves this issue.
